### PR TITLE
feat: script mappers module

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       - DB_DATABASE=keycloak
       - DB_USER=keycloak
       - DB_PASSWORD=keycloak
+      - USER_API_KEY=user-api-key
+      - FDK_CLIENT_SECRET=secret
     depends_on:
       - sso-db
 

--- a/helm-sources/templates/deployment.yaml
+++ b/helm-sources/templates/deployment.yaml
@@ -71,6 +71,16 @@ spec:
             secretKeyRef:
               name: postgres-{{ required "Missing value NAMESPACE" .Values.NAMESPACE }}
               key: PASSWORD
+        - name: USER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: common-{{ required "Missing value NAMESPACE" .Values.NAMESPACE }}
+              key: SSO_API_KEY
+        - name: FDK_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: sso-{{ required "Missing value NAMESPACE" .Values.NAMESPACE }}
+              key: FDK_CLIENT_SECRET
         name: sso
         image: {{ required "Missing value DOCKER_IMAGE_NAME" .Values.DOCKER_IMAGE_NAME }}
         imagePullPolicy: Always

--- a/modules/fdk-scripts/META-INF/keycloak-scripts.json
+++ b/modules/fdk-scripts/META-INF/keycloak-scripts.json
@@ -1,0 +1,26 @@
+{
+    "authenticators": [ ],
+    "policies": [ ],
+    "mappers": [
+        {
+            "name": "FDK terms version mapper",
+            "fileName": "terms-mapper.js",
+            "description": "Maps latest terms version"
+        },
+        {
+            "name": "FDK authorities mapper",
+            "fileName": "authorities-mapper.js",
+            "description": "Maps FDK authorities"
+        },
+        {
+            "name": "FDK accepted terms version mapper",
+            "fileName": "accepted-terms-mapper.js",
+            "description": "Maps the latest terms version accepted by the organization"
+        },
+        {
+            "name": "FDK username mapper",
+            "fileName": "username-mapper.js",
+            "description": "Maps idp-username to fdk-username"
+        }
+    ]
+}

--- a/modules/fdk-scripts/accepted-terms-mapper.js
+++ b/modules/fdk-scripts/accepted-terms-mapper.js
@@ -21,14 +21,11 @@ forEach.call(user.getAttribute("login_type"), function(type){
 
 if (isDifiLogin) {
     var orgs = user.getAttribute("orgnr");
-    var firstInList = true;
     urlBuilder.append("difi?orgs=");
 
-    forEach.call(orgs, function(org) {
-        if (firstInList !== true) {
+    forEach.call(orgs, function(org, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(org);
@@ -36,14 +33,11 @@ if (isDifiLogin) {
 
 } else if (isOkLogin) {
     var orgnames = user.getAttribute("ok_orgnames");
-    var firstInList = true;
     urlBuilder.append("oslokommune?orgnames=");
 
-    forEach.call(orgnames, function(org) {
-        if (firstInList !== true) {
+    forEach.call(orgnames, function(org, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(org);

--- a/modules/fdk-scripts/accepted-terms-mapper.js
+++ b/modules/fdk-scripts/accepted-terms-mapper.js
@@ -1,0 +1,59 @@
+var System = Java.type("java.lang.System");
+var StringBuilder = Java.type("java.lang.StringBuilder");
+var SimpleHttp = Java.type("org.keycloak.broker.provider.util.SimpleHttp");
+
+var forEach = Array.prototype.forEach;
+
+var urlBuilder = new StringBuilder();
+
+urlBuilder.append("http://user-api:8080/terms/");
+
+var isDifiLogin = false;
+var isOkLogin = false;
+forEach.call(user.getAttribute("login_type"), function(type){
+    if (type === "difi") {
+        isDifiLogin = true;
+    }
+    if (type === "ok") {
+        isOkLogin = true;
+    }
+});
+
+if (isDifiLogin) {
+    var orgs = user.getAttribute("orgnr");
+    var firstInList = true;
+    urlBuilder.append("difi?orgs=");
+
+    forEach.call(orgs, function(org) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(org);
+    });
+
+} else if (isOkLogin) {
+    var orgnames = user.getAttribute("ok_orgnames");
+    var firstInList = true;
+    urlBuilder.append("oslokommune?orgnames=");
+
+    forEach.call(orgnames, function(org) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(org);
+    });
+
+} else {
+    urlBuilder.append("altinn/");
+    urlBuilder.append(user.username);
+}
+
+var url = urlBuilder.toString()
+
+exports = SimpleHttp.doGet(url, keycloakSession).header("X-API-KEY", System.getenv().get("USER_API_KEY")).asString();

--- a/modules/fdk-scripts/authorities-mapper.js
+++ b/modules/fdk-scripts/authorities-mapper.js
@@ -23,27 +23,21 @@ if (isDifiLogin) {
     var orgs = user.getAttribute("orgnr");
     var roles = user.getAttribute("difi_roles");
 
-    var firstInList = true;
     urlBuilder.append("difi?roles=");
 
-    forEach.call(roles, function(role) {
-        if (firstInList !== true) {
+    forEach.call(roles, function(role, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(role.replace("brukar ", ""));
     });
 
-    firstInList = true;
     urlBuilder.append("&orgs=");
 
-    forEach.call(orgs, function(org) {
-        if (firstInList !== true) {
+    forEach.call(orgs, function(org, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(org);
@@ -53,25 +47,19 @@ if (isDifiLogin) {
     var roles = user.getAttribute("ok_roles");
     var orgnames = user.getAttribute("ok_orgnames");
 
-    var firstInList = true;
     urlBuilder.append("oslokommune?roles=");
-    forEach.call(roles, function(role) {
-        if (firstInList !== true) {
+    forEach.call(roles, function(role, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(role);
     });
 
-    var firstInList = true;
     urlBuilder.append("&orgnames=");
-    forEach.call(orgnames, function(orgname) {
-        if (firstInList !== true) {
+    forEach.call(orgnames, function(orgname, index) {
+        if (index !== 0) {
             urlBuilder.append(",");
-        } else {
-            firstInList = false;
         }
 
         urlBuilder.append(orgname);

--- a/modules/fdk-scripts/authorities-mapper.js
+++ b/modules/fdk-scripts/authorities-mapper.js
@@ -1,0 +1,91 @@
+var System = Java.type("java.lang.System");
+var StringBuilder = Java.type("java.lang.StringBuilder");
+var SimpleHttp = Java.type("org.keycloak.broker.provider.util.SimpleHttp");
+
+var forEach = Array.prototype.forEach;
+
+var urlBuilder = new StringBuilder();
+
+urlBuilder.append("http://user-api:8080/authorities/");
+
+var isDifiLogin = false;
+var isOkLogin = false;
+forEach.call(user.getAttribute("login_type"), function(type){
+    if (type === "difi") {
+        isDifiLogin = true;
+    }
+    if (type === "ok") {
+        isOkLogin = true;
+    }
+});
+
+if (isDifiLogin) {
+    var orgs = user.getAttribute("orgnr");
+    var roles = user.getAttribute("difi_roles");
+
+    var firstInList = true;
+    urlBuilder.append("difi?roles=");
+
+    forEach.call(roles, function(role) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(role.replace("brukar ", ""));
+    });
+
+    firstInList = true;
+    urlBuilder.append("&orgs=");
+
+    forEach.call(orgs, function(org) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(org);
+    });
+
+} else if (isOkLogin) {
+    var roles = user.getAttribute("ok_roles");
+    var orgnames = user.getAttribute("ok_orgnames");
+
+    var firstInList = true;
+    urlBuilder.append("oslokommune?roles=");
+    forEach.call(roles, function(role) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(role);
+    });
+
+    var firstInList = true;
+    urlBuilder.append("&orgnames=");
+    forEach.call(orgnames, function(orgname) {
+        if (firstInList !== true) {
+            urlBuilder.append(",");
+        } else {
+            firstInList = false;
+        }
+
+        urlBuilder.append(orgname);
+    });
+
+} else {
+    urlBuilder.append("altinn/");
+    urlBuilder.append(user.username);
+}
+
+var url = urlBuilder.toString();
+var response = SimpleHttp.doGet(url, keycloakSession).header("X-API-KEY", System.getenv().get("USER_API_KEY")).asResponse();
+if (response.getStatus() === 200) {
+    exports = response.asString();
+} else {
+    throw new Error('User-api authorities status: ' + response.getStatus());
+}

--- a/modules/fdk-scripts/terms-mapper.js
+++ b/modules/fdk-scripts/terms-mapper.js
@@ -1,0 +1,5 @@
+var SimpleHttp = Java.type("org.keycloak.broker.provider.util.SimpleHttp");
+
+var url = "http://terms-and-conditions:8080/terms/latest/version"
+
+exports = SimpleHttp.doGet(url, keycloakSession).asString();

--- a/modules/fdk-scripts/username-mapper.js
+++ b/modules/fdk-scripts/username-mapper.js
@@ -1,0 +1,6 @@
+var System = Java.type("java.lang.System");
+var UUID = Java.type("java.util.UUID");
+
+var uuidBase = System.getenv().get("FDK_CLIENT_SECRET") + user.getUsername();
+
+exports = UUID.nameUUIDFromBytes(uuidBase.getBytes());


### PR DESCRIPTION
Litt info rundt disse javascript-mapperene
- Er ikke mulig å laste inn pakker fra npm ol, i hvert fall ikke som jeg jeg har klart å få til
- Vi kan importere ting fra java-miljøet keycloak kjører i
- Verdien vi gir `exports`-variabelen til er resultatet av mapperen, dvs verdien som blir satt til relevant claim

info keycloak gir om du oppretter en ny script mapper:
```
/**
 * Available variables: 
 * user - the current user
 * realm - the current realm
 * token - the current token
 * userSession - the current userSession
 * keycloakSession - the current keycloakSession
 */
 ```