### PR TITLE
chore: bump keycloak to 26.5.6

### DIFF
--- a/modules/rest-user-mapper/pom.xml
+++ b/modules/rest-user-mapper/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.compiler.maven.plugin>3.14.1</version.compiler.maven.plugin>
-        <keycloak-version>26.5.5</keycloak-version>
+        <keycloak-version>26.5.6</keycloak-version>
         <keycloak-admin-client-version>26.0.8</keycloak-admin-client-version>
     </properties>
 


### PR DESCRIPTION
 - Bump keycloak-version from 26.5.6 in rest-user-mapper to fix security vulnerabilities                                                                              
 - Resolves Dependabot alerts for SAML IdP auth bypass, encrypted SAML assertion injection, offline session handling, and SAMLRequest decompression DoS               
