### PR TITLE
chore: bump keycloak to 26.6.2

### DIFF
--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -16,6 +16,6 @@ jobs:
       app_name: sso
       environment: prod
       gh_environment: prod
-      version: 26.6.1
+      version: 26.6.2
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -17,7 +17,7 @@ jobs:
       app_name: sso
       environment: staging
       gh_environment: staging
-      version: 26.6.1
+      version: 26.6.2
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN jar -cvf fdk-scripts.jar *
 ###################################
 
 
-FROM quay.io/keycloak/keycloak:26.6.1
+FROM quay.io/keycloak/keycloak:26.6.2
 
 # copy deployment modules from maven environment
 COPY --from=build /tmp/rest-user-mapper/target/rest-user-mapper.jar /opt/keycloak/providers/rest-user-mapper.jar

--- a/modules/rest-user-mapper/pom.xml
+++ b/modules/rest-user-mapper/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.compiler.maven.plugin>3.15.0</version.compiler.maven.plugin>
-        <keycloak-version>26.6.1</keycloak-version>
+        <keycloak-version>26.6.2</keycloak-version>
         <keycloak-admin-client-version>26.0.8</keycloak-admin-client-version>
     </properties>
 


### PR DESCRIPTION
# Summary

- Bump Keycloak base image from 26.6.1 to 26.6.2 in Dockerfile
- Update keycloak-version in pom.xml to 26.6.2
- Update version in build-prod.yaml and build-staging.yaml workflows

Picks up 16 security fixes in 26.6.2 (incl. CVE-2026-7507 session fixation, CVE-2026-7504 redirect URI bypass). Note: CVE-2026-7500 (Dependabot #171) has no released fix yet and is not applicable here since the account feature is not disabled.