### PR TITLE
chore: bump keycloak to 26.6.3

### DIFF
--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -16,6 +16,6 @@ jobs:
       app_name: sso
       environment: prod
       gh_environment: prod
-      version: 26.6.2
+      version: 26.6.3
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -17,7 +17,7 @@ jobs:
       app_name: sso
       environment: staging
       gh_environment: staging
-      version: 26.6.2
+      version: 26.6.3
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN jar -cvf fdk-scripts.jar *
 ###################################
 
 
-FROM quay.io/keycloak/keycloak:26.6.2
+FROM quay.io/keycloak/keycloak:26.6.3
 
 # copy deployment modules from maven environment
 COPY --from=build /tmp/rest-user-mapper/target/rest-user-mapper.jar /opt/keycloak/providers/rest-user-mapper.jar

--- a/modules/rest-user-mapper/pom.xml
+++ b/modules/rest-user-mapper/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.compiler.maven.plugin>3.15.0</version.compiler.maven.plugin>
-        <keycloak-version>26.6.2</keycloak-version>
+        <keycloak-version>26.6.3</keycloak-version>
         <keycloak-admin-client-version>26.0.8</keycloak-admin-client-version>
     </properties>
 


### PR DESCRIPTION
# Summary

- Bump Keycloak from 26.6.2 to 26.6.3 in Dockerfile, build workflows, and rest-user-mapper pom.xml
- Fixes Dependabot alert #181 (WebAuthn policy bypass during credential registration, CVE fixed in 26.6.3)