### PR TITLE
fix: bump keycloak to 26.6.4

### DIFF
--- a/modules/rest-user-mapper/pom.xml
+++ b/modules/rest-user-mapper/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.compiler.maven.plugin>3.15.0</version.compiler.maven.plugin>
-        <keycloak-version>26.6.3</keycloak-version>
+        <keycloak-version>26.6.4</keycloak-version>
         <keycloak-admin-client-version>26.0.8</keycloak-admin-client-version>
     </properties>
 


### PR DESCRIPTION
# Summary

- Bump keycloak-version 26.6.3 → 26.6.4 to fix keycloak-services vulnerability (#188, High)
- #187/#189/#190 have no patched release available yet and remain open
- Verified: module compiles with mvn compile