### PR TITLE
fix: bump keycloak to 26.7.0

### DIFF
--- a/.github/workflows/build-prod.yaml
+++ b/.github/workflows/build-prod.yaml
@@ -16,6 +16,6 @@ jobs:
       app_name: sso
       environment: prod
       gh_environment: prod
-      version: 26.6.3
+      version: 26.7.0
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -17,7 +17,7 @@ jobs:
       app_name: sso
       environment: staging
       gh_environment: staging
-      version: 26.6.3
+      version: 26.7.0
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN jar -cvf fdk-scripts.jar *
 ###################################
 
 
-FROM quay.io/keycloak/keycloak:26.6.3
+FROM quay.io/keycloak/keycloak:26.7.0
 
 # copy deployment modules from maven environment
 COPY --from=build /tmp/rest-user-mapper/target/rest-user-mapper.jar /opt/keycloak/providers/rest-user-mapper.jar

--- a/modules/rest-user-mapper/pom.xml
+++ b/modules/rest-user-mapper/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.compiler.maven.plugin>3.15.0</version.compiler.maven.plugin>
-        <keycloak-version>26.6.4</keycloak-version>
+        <keycloak-version>26.7.0</keycloak-version>
         <keycloak-admin-client-version>26.0.8</keycloak-admin-client-version>
     </properties>
 


### PR DESCRIPTION
# Summary

- Bump keycloak-version 26.6.4 → 26.7.0 in rest-user-mapper — fixes #191 (keycloak-services, Low)
- Verified: module compiles with mvn compile
